### PR TITLE
add support to get secret scanning alerts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -130,6 +130,19 @@
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "list-repo-secret-scan-alerts",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeExecutable": "tsx",
+      "program": "${workspaceFolder}/src/index.ts",
+      "args": ["list-repo-secret-scan-alerts"],
+      "sourceMaps": true,
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@octokit/plugin-rest-endpoint-methods": "^16.1.1",
         "@scottluskcis/octokit-harness": "^0.0.11",
         "@types/tar": "^6.1.13",
         "csv-parse": "^5.6.0",
         "filesize": "^10.1.6",
+        "octokit": "^5.0.4",
         "tar": "^7.4.3"
       },
       "devDependencies": {
@@ -831,17 +833,17 @@
       }
     },
     "node_modules/@octokit/app": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.0.tgz",
-      "integrity": "sha512-OdKHnm0CYLk8Setr47CATT4YnRTvWkpTYvE+B/l2B0mjszlfOIit3wqPHVslD2jfc1bD4UbO7Mzh6gjCuMZKsA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.1.tgz",
+      "integrity": "sha512-pcvKSN6Q6aT3gU5heoDFs3ywU5xejxeqs1rQpUwgN7CmBlxCSy9aCoqFuC6GpVv71O/Qq/VuYfCNzrOZp/9Ycw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-app": "^8.1.0",
-        "@octokit/auth-unauthenticated": "^7.0.1",
-        "@octokit/core": "^7.0.2",
-        "@octokit/oauth-app": "^8.0.1",
-        "@octokit/plugin-paginate-rest": "^13.0.0",
-        "@octokit/types": "^14.0.0",
+        "@octokit/auth-app": "^8.1.1",
+        "@octokit/auth-unauthenticated": "^7.0.2",
+        "@octokit/core": "^7.0.5",
+        "@octokit/oauth-app": "^8.0.2",
+        "@octokit/plugin-paginate-rest": "^13.2.0",
+        "@octokit/types": "^15.0.0",
         "@octokit/webhooks": "^14.0.0"
       },
       "engines": {
@@ -849,16 +851,16 @@
       }
     },
     "node_modules/@octokit/auth-app": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.1.0.tgz",
-      "integrity": "sha512-6bWhyvLXqCSfHiqlwzn9pScLZ+Qnvh/681GR/UEEPCMIVwfpRDBw0cCzy3/t2Dq8B7W2X/8pBgmw6MOiyE0DXQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.1.1.tgz",
+      "integrity": "sha512-yW9YUy1cuqWlz8u7908ed498wJFt42VYsYWjvepjojM4BdZSp4t+5JehFds7LfvYi550O/GaUI94rgbhswvxfA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-app": "^9.0.1",
-        "@octokit/auth-oauth-user": "^6.0.0",
-        "@octokit/request": "^10.0.2",
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0",
+        "@octokit/auth-oauth-app": "^9.0.2",
+        "@octokit/auth-oauth-user": "^6.0.1",
+        "@octokit/request": "^10.0.5",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
         "toad-cache": "^3.7.0",
         "universal-github-app-jwt": "^2.2.0",
         "universal-user-agent": "^7.0.0"
@@ -868,15 +870,15 @@
       }
     },
     "node_modules/@octokit/auth-oauth-app": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.1.tgz",
-      "integrity": "sha512-TthWzYxuHKLAbmxdFZwFlmwVyvynpyPmjwc+2/cI3cvbT7mHtsAW9b1LvQaNnAuWL+pFnqtxdmrU8QpF633i1g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.2.tgz",
+      "integrity": "sha512-vmjSHeuHuM+OxZLzOuoYkcY3OPZ8erJ5lfswdTmm+4XiAKB5PmCk70bA1is4uwSl/APhRVAv4KHsgevWfEKIPQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^8.0.1",
-        "@octokit/auth-oauth-user": "^6.0.0",
-        "@octokit/request": "^10.0.2",
-        "@octokit/types": "^14.0.0",
+        "@octokit/auth-oauth-device": "^8.0.2",
+        "@octokit/auth-oauth-user": "^6.0.1",
+        "@octokit/request": "^10.0.5",
+        "@octokit/types": "^15.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -884,14 +886,14 @@
       }
     },
     "node_modules/@octokit/auth-oauth-device": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.1.tgz",
-      "integrity": "sha512-TOqId/+am5yk9zor0RGibmlqn4V0h8vzjxlw/wYr3qzkQxl8aBPur384D1EyHtqvfz0syeXji4OUvKkHvxk/Gw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.2.tgz",
+      "integrity": "sha512-KW7Ywrz7ei7JX+uClWD2DN1259fnkoKuVdhzfpQ3/GdETaCj4Tx0IjvuJrwhP/04OhcMu5yR6tjni0V6LBihdw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/oauth-methods": "^6.0.0",
-        "@octokit/request": "^10.0.2",
-        "@octokit/types": "^14.0.0",
+        "@octokit/oauth-methods": "^6.0.1",
+        "@octokit/request": "^10.0.5",
+        "@octokit/types": "^15.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -899,15 +901,15 @@
       }
     },
     "node_modules/@octokit/auth-oauth-user": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.0.tgz",
-      "integrity": "sha512-GV9IW134PHsLhtUad21WIeP9mlJ+QNpFd6V9vuPWmaiN25HEJeEQUcS4y5oRuqCm9iWDLtfIs+9K8uczBXKr6A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.1.tgz",
+      "integrity": "sha512-vlKsL1KUUPvwXpv574zvmRd+/4JiDFXABIZNM39+S+5j2kODzGgjk7w5WtiQ1x24kRKNaE7v9DShNbw43UA3Hw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^8.0.1",
-        "@octokit/oauth-methods": "^6.0.0",
-        "@octokit/request": "^10.0.2",
-        "@octokit/types": "^14.0.0",
+        "@octokit/auth-oauth-device": "^8.0.2",
+        "@octokit/oauth-methods": "^6.0.1",
+        "@octokit/request": "^10.0.5",
+        "@octokit/types": "^15.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -924,28 +926,28 @@
       }
     },
     "node_modules/@octokit/auth-unauthenticated": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.1.tgz",
-      "integrity": "sha512-qVq1vdjLLZdE8kH2vDycNNjuJRCD1q2oet1nA/GXWaYlpDxlR7rdVhX/K/oszXslXiQIiqrQf+rdhDlA99JdTQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.2.tgz",
+      "integrity": "sha512-vjcPRP1xsKWdYKiyKmHkLFCxeH4QvVTv05VJlZxwNToslBFcHRJlsWRaoI2+2JGCf9tIM99x8cN0b1rlAHJiQw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0"
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.4.tgz",
-      "integrity": "sha512-jOT8V1Ba5BdC79sKrRWDdMT5l1R+XNHTPR6CPWzUP2EcfAcvIHZWF0eAbmRcpOOP5gVIwnqNg0C4nvh6Abc3OA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.1",
-        "@octokit/request": "^10.0.2",
-        "@octokit/request-error": "^7.0.0",
+        "@octokit/graphql": "^9.0.2",
+        "@octokit/request": "^10.0.4",
+        "@octokit/request-error": "^7.0.1",
         "@octokit/types": "^15.0.0",
         "before-after-hook": "^4.0.0",
         "universal-user-agent": "^7.0.0"
@@ -954,28 +956,13 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
-      "integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
-      "integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^26.0.0"
-      }
-    },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
-      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.1.tgz",
+      "integrity": "sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^14.0.0",
+        "@octokit/types": "^15.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -983,13 +970,13 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
-      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.2.tgz",
+      "integrity": "sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^10.0.2",
-        "@octokit/types": "^14.0.0",
+        "@octokit/request": "^10.0.4",
+        "@octokit/types": "^15.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -997,17 +984,17 @@
       }
     },
     "node_modules/@octokit/oauth-app": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.1.tgz",
-      "integrity": "sha512-QnhMYEQpnYbEPn9cae+wXL2LuPMFglmfeuDJXXsyxIXdoORwkLK8y0cHhd/5du9MbO/zdG/BXixzB7EEwU63eQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.3.tgz",
+      "integrity": "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-app": "^9.0.1",
-        "@octokit/auth-oauth-user": "^6.0.0",
-        "@octokit/auth-unauthenticated": "^7.0.1",
-        "@octokit/core": "^7.0.2",
+        "@octokit/auth-oauth-app": "^9.0.2",
+        "@octokit/auth-oauth-user": "^6.0.1",
+        "@octokit/auth-unauthenticated": "^7.0.2",
+        "@octokit/core": "^7.0.5",
         "@octokit/oauth-authorization-url": "^8.0.0",
-        "@octokit/oauth-methods": "^6.0.0",
+        "@octokit/oauth-methods": "^6.0.1",
         "@types/aws-lambda": "^8.10.83",
         "universal-user-agent": "^7.0.0"
       },
@@ -1025,24 +1012,24 @@
       }
     },
     "node_modules/@octokit/oauth-methods": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.0.tgz",
-      "integrity": "sha512-Q8nFIagNLIZgM2odAraelMcDssapc+lF+y3OlcIPxyAU+knefO8KmozGqfnma1xegRDP4z5M73ABsamn72bOcA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.1.tgz",
+      "integrity": "sha512-xi6Iut3izMCFzXBJtxxJehxJmAKjE8iwj6L5+raPRwlTNKAbOOBJX7/Z8AF5apD4aXvc2skwIdOnC+CQ4QuA8Q==",
       "license": "MIT",
       "dependencies": {
         "@octokit/oauth-authorization-url": "^8.0.0",
-        "@octokit/request": "^10.0.2",
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0"
+        "@octokit/request": "^10.0.5",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
+      "integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
@@ -1064,12 +1051,12 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
-      "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.2.1.tgz",
+      "integrity": "sha512-Tj4PkZyIL6eBMYcG/76QGsedF0+dWVeLhYprTmuFVVxzDW7PQh23tM0TP0z+1MvSkxB29YFZwnUX+cXfTiSdyw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^14.1.0"
+        "@octokit/types": "^15.0.1"
       },
       "engines": {
         "node": ">= 20"
@@ -1079,12 +1066,12 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.1.0.tgz",
-      "integrity": "sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.1.1.tgz",
+      "integrity": "sha512-VztDkhM0ketQYSh5Im3IcKWFZl7VIrrsCaHbDINkdYeiiAsJzjhS2xRFCSJgfN6VOcsoW4laMtsmf3HcNqIimg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^15.0.0"
+        "@octokit/types": "^15.0.1"
       },
       "engines": {
         "node": ">= 20"
@@ -1093,29 +1080,14 @@
         "@octokit/core": ">=6"
       }
     },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-26.0.0.tgz",
-      "integrity": "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.0.tgz",
-      "integrity": "sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^26.0.0"
-      }
-    },
     "node_modules/@octokit/plugin-retry": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
-      "integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.2.tgz",
+      "integrity": "sha512-mVPCe77iaD8g1lIX46n9bHPUirFLzc3BfIzsZOpB7bcQh1ecS63YsAgcsyMGqvGa2ARQWKEFTrhMJX2MLJVHVw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -1126,12 +1098,12 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
-      "integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.2.tgz",
+      "integrity": "sha512-ntNIig4zZhQVOZF4fG9Wt8QCoz9ehb+xnlUwp74Ic2ANChCk8oKmRwV9zDDCtrvU1aERIOvtng8wsalEX7Jk5Q==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^14.0.0",
+        "@octokit/types": "^15.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -1142,14 +1114,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
-      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.5.tgz",
+      "integrity": "sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.0",
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0",
+        "@octokit/endpoint": "^11.0.1",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
         "fast-content-type-parse": "^3.0.0",
         "universal-user-agent": "^7.0.2"
       },
@@ -1158,24 +1130,24 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
-      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.1.tgz",
+      "integrity": "sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^14.0.0"
+        "@octokit/types": "^15.0.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-15.0.1.tgz",
+      "integrity": "sha512-sdiirM93IYJ9ODDCBgmRPIboLbSkpLa5i+WLuXH8b8Atg+YMLAyLvDDhNWLV4OYd08tlvYfVm/dw88cqHWtw1Q==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^25.1.0"
+        "@octokit/openapi-types": "^26.0.0"
       }
     },
     "node_modules/@octokit/webhooks": {
@@ -1650,9 +1622,9 @@
       "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.152",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
-      "integrity": "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==",
+      "version": "8.10.156",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.156.tgz",
+      "integrity": "sha512-LElQP+QliVWykC7OF8dNr04z++HJCMO2lF7k9HuKoSDARqhcjHq8MzbrRwujCSDeBHIlvaimbuY/tVZL36KXFQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3164,21 +3136,21 @@
       "license": "MIT"
     },
     "node_modules/octokit": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.3.tgz",
-      "integrity": "sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.4.tgz",
+      "integrity": "sha512-4n/mMoLQs2npBE+aTG5o4H+hZhFKu8aDqZFP/nmUNRUYrTpXpaqvX1ppK5eiCtQ+uP/8jI6vbdfCB2udlBgccA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/app": "^16.0.1",
-        "@octokit/core": "^7.0.2",
-        "@octokit/oauth-app": "^8.0.1",
+        "@octokit/app": "^16.1.1",
+        "@octokit/core": "^7.0.5",
+        "@octokit/oauth-app": "^8.0.2",
         "@octokit/plugin-paginate-graphql": "^6.0.0",
-        "@octokit/plugin-paginate-rest": "^13.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^16.0.0",
-        "@octokit/plugin-retry": "^8.0.1",
-        "@octokit/plugin-throttling": "^11.0.1",
-        "@octokit/request-error": "^7.0.0",
-        "@octokit/types": "^14.0.0",
+        "@octokit/plugin-paginate-rest": "^13.2.0",
+        "@octokit/plugin-rest-endpoint-methods": "^16.1.0",
+        "@octokit/plugin-retry": "^8.0.2",
+        "@octokit/plugin-throttling": "^11.0.2",
+        "@octokit/request-error": "^7.0.1",
+        "@octokit/types": "^15.0.0",
         "@octokit/webhooks": "^14.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@octokit/plugin-rest-endpoint-methods": "^16.1.1",
     "@scottluskcis/octokit-harness": "^0.0.11",
     "@types/tar": "^6.1.13",
     "csv-parse": "^5.6.0",
     "filesize": "^10.1.6",
+    "octokit": "^5.0.4",
     "tar": "^7.4.3"
   },
   "devDependencies": {

--- a/src/api/secret-scanning/secret-scanning-alerts.ts
+++ b/src/api/secret-scanning/secret-scanning-alerts.ts
@@ -19,6 +19,19 @@ export type SecretScanningAlertOptions = {
   hide_secret: boolean | undefined;
 };
 
+export type SecretScanningAlertOrgOptions = {
+  org: string;
+  state: 'open' | 'resolved' | undefined;
+  secret_type: string | undefined;
+  resolution: string | undefined;
+  validity: string | undefined;
+  page: number;
+  per_page: number;
+  is_publicly_leaked: boolean | undefined;
+  is_multi_repo: boolean | undefined;
+  hide_secret: boolean | undefined;
+};
+
 export async function* listAlertsForRepo({
   octokit,
   owner,
@@ -115,6 +128,55 @@ export async function* listAlertsForRepos({
       hide_secret,
     })) {
       yield { ...alert, owner, repo };
+    }
+  }
+}
+
+export async function* listAlertsForOrg({
+  octokit,
+  org,
+  state,
+  secret_type,
+  resolution,
+  validity,
+  page = 1,
+  per_page = 30,
+  is_publicly_leaked = false,
+  is_multi_repo = false,
+  hide_secret = false,
+}: {
+  octokit: Octokit;
+} & SecretScanningAlertOrgOptions): AsyncGenerator<
+  SecretScanningAlert,
+  void,
+  unknown
+> {
+  if (!octokit) {
+    throw new Error('Octokit instance is required');
+  }
+  if (!org) {
+    throw new Error('Organization is required');
+  }
+
+  const iterator = octokit.paginate.iterator(
+    octokit.rest.secretScanning.listAlertsForOrg,
+    {
+      org,
+      state,
+      secret_type,
+      resolution,
+      validity,
+      is_publicly_leaked,
+      per_page: per_page,
+      page: page,
+      is_multi_repo,
+      hide_secret,
+    },
+  );
+
+  for await (const { data: alerts } of iterator) {
+    for (const alert of alerts) {
+      yield alert;
     }
   }
 }

--- a/src/api/secret-scanning/secret-scanning-alerts.ts
+++ b/src/api/secret-scanning/secret-scanning-alerts.ts
@@ -1,0 +1,120 @@
+import { Octokit } from 'octokit';
+import { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
+
+export type SecretScanningAlert =
+  RestEndpointMethodTypes['secretScanning']['listAlertsForRepo']['response']['data'][number];
+
+export type SecretScanningAlertOptions = {
+  owner: string;
+  repo: string | undefined;
+  repos?: { owner: string; repo: string }[] | undefined;
+  state: 'open' | 'resolved' | undefined;
+  secret_type: string | undefined;
+  resolution: string | undefined;
+  validity: string | undefined;
+  page: number;
+  per_page: number;
+  is_publicly_leaked: boolean | undefined;
+  is_multi_repo: boolean | undefined;
+  hide_secret: boolean | undefined;
+};
+
+export async function* listAlertsForRepo({
+  octokit,
+  owner,
+  repo,
+  state,
+  secret_type,
+  resolution,
+  validity,
+  page = 1,
+  per_page = 30,
+  is_publicly_leaked = false,
+  is_multi_repo = false,
+  hide_secret = false,
+}: {
+  octokit: Octokit;
+} & SecretScanningAlertOptions): AsyncGenerator<
+  SecretScanningAlert,
+  void,
+  unknown
+> {
+  if (!octokit) {
+    throw new Error('Octokit instance is required');
+  }
+  if (!owner) {
+    throw new Error('Owner is required');
+  }
+  if (!repo) {
+    throw new Error('Repo is required');
+  }
+
+  const iterator = octokit.paginate.iterator(
+    octokit.rest.secretScanning.listAlertsForRepo,
+    {
+      owner,
+      repo,
+      state,
+      secret_type,
+      resolution,
+      validity,
+      is_publicly_leaked,
+      per_page: per_page,
+      page: page,
+      is_multi_repo,
+      hide_secret,
+    },
+  );
+
+  for await (const { data: alerts } of iterator) {
+    for (const alert of alerts) {
+      yield alert;
+    }
+  }
+}
+
+export async function* listAlertsForRepos({
+  octokit,
+  repos,
+  state,
+  secret_type,
+  resolution,
+  validity,
+  page = 1,
+  per_page = 30,
+  is_publicly_leaked = false,
+  is_multi_repo = false,
+  hide_secret = false,
+}: {
+  octokit: Octokit;
+} & SecretScanningAlertOptions): AsyncGenerator<
+  SecretScanningAlert & {
+    owner: string;
+    repo: string;
+  },
+  void,
+  unknown
+> {
+  if (!repos || repos.length === 0) {
+    throw new Error('At least one repository must be specified.');
+  }
+
+  for (const { owner, repo } of repos) {
+    for await (const alert of listAlertsForRepo({
+      octokit,
+      owner,
+      repo,
+      state,
+      secret_type,
+      resolution,
+      validity,
+      page,
+      per_page,
+      is_publicly_leaked,
+      is_multi_repo,
+      hide_secret,
+    })) {
+      yield { ...alert, owner, repo };
+    }
+  }
+}

--- a/src/api/secret-scanning/secret-scanning-alerts.ts
+++ b/src/api/secret-scanning/secret-scanning-alerts.ts
@@ -42,8 +42,8 @@ export async function* listAlertsForRepo({
   validity,
   page = 1,
   per_page = 30,
-  is_publicly_leaked = false,
-  is_multi_repo = false,
+  is_publicly_leaked = undefined,
+  is_multi_repo = undefined,
   hide_secret = false,
 }: {
   octokit: Octokit;
@@ -95,8 +95,8 @@ export async function* listAlertsForRepos({
   validity,
   page = 1,
   per_page = 30,
-  is_publicly_leaked = false,
-  is_multi_repo = false,
+  is_publicly_leaked = undefined,
+  is_multi_repo = undefined,
   hide_secret = false,
 }: {
   octokit: Octokit;
@@ -141,8 +141,8 @@ export async function* listAlertsForOrg({
   validity,
   page = 1,
   per_page = 30,
-  is_publicly_leaked = false,
-  is_multi_repo = false,
+  is_publicly_leaked = undefined,
+  is_multi_repo = undefined,
   hide_secret = false,
 }: {
   octokit: Octokit;

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -1,0 +1,195 @@
+import { Command, Option } from 'commander';
+
+// Helper functions for parsing
+export function parseIntOption(value: string): number {
+  const parsed = parseInt(value, 10);
+  if (isNaN(parsed)) {
+    throw new Error(`Invalid integer value: ${value}`);
+  }
+  return parsed;
+}
+
+export function parseFloatOption(value: string): number {
+  const parsed = parseFloat(value);
+  if (isNaN(parsed)) {
+    throw new Error(`Invalid float value: ${value}`);
+  }
+  return parsed;
+}
+
+export function parseRepoListOption(
+  value: string,
+): { owner: string; repo: string }[] {
+  return value.split(',').map((fullName) => {
+    const [owner, repo] = fullName.split('/');
+    return { owner, repo };
+  });
+}
+
+export function withSharedOptions(cmd: Command): Command {
+  return (
+    cmd
+      // Organization and authentication options
+      .addOption(
+        new Option(
+          '-o, --org-name <org>',
+          'The name of the organization to process',
+        ).env('ORG_NAME'),
+      )
+      .addOption(
+        new Option('-t, --access-token <token>', 'GitHub access token').env(
+          'ACCESS_TOKEN',
+        ),
+      )
+      .addOption(
+        new Option('-u, --base-url <url>', 'GitHub API base URL')
+          .env('BASE_URL')
+          .default('https://api.github.com'),
+      )
+      .addOption(
+        new Option('--proxy-url <url>', 'Proxy URL if required').env(
+          'PROXY_URL',
+        ),
+      )
+      .addOption(
+        new Option('-v, --verbose', 'Enable verbose logging').env('VERBOSE'),
+      )
+      // GitHub App authentication options
+      .addOption(new Option('--app-id <id>', 'GitHub App ID').env('APP_ID'))
+      .addOption(
+        new Option('--private-key <key>', 'GitHub App private key').env(
+          'PRIVATE_KEY',
+        ),
+      )
+      .addOption(
+        new Option(
+          '--private-key-file <file>',
+          'Path to GitHub App private key file',
+        ).env('PRIVATE_KEY_FILE'),
+      )
+      .addOption(
+        new Option(
+          '--app-installation-id <id>',
+          'GitHub App installation ID',
+        ).env('APP_INSTALLATION_ID'),
+      )
+      // Pagination options
+      .addOption(
+        new Option('--page <page>', 'Page to start from')
+          .env('PAGE')
+          .default('1')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option('--page-size <size>', 'Number of items per page')
+          .env('PAGE_SIZE')
+          .default('10')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option('--extra-page-size <size>', 'Extra page size')
+          .env('EXTRA_PAGE_SIZE')
+          .default('50')
+          .argParser(parseIntOption),
+      )
+      // Rate limiting options
+      .addOption(
+        new Option(
+          '--rate-limit-check-interval <seconds>',
+          'Interval for rate limit checks in seconds',
+        )
+          .env('RATE_LIMIT_CHECK_INTERVAL')
+          .default('25')
+          .argParser(parseIntOption),
+      )
+      // Retry mechanism options
+      .addOption(
+        new Option(
+          '--retry-max-attempts <attempts>',
+          'Maximum number of retry attempts',
+        )
+          .env('RETRY_MAX_ATTEMPTS')
+          .default('3')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option(
+          '--retry-initial-delay <milliseconds>',
+          'Initial delay for retry in milliseconds',
+        )
+          .env('RETRY_INITIAL_DELAY')
+          .default('1000')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option(
+          '--retry-max-delay <milliseconds>',
+          'Maximum delay for retry in milliseconds',
+        )
+          .env('RETRY_MAX_DELAY')
+          .default('30000')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option(
+          '--retry-backoff-factor <factor>',
+          'Backoff factor for retry delays',
+        )
+          .env('RETRY_BACKOFF_FACTOR')
+          .default('2')
+          .argParser(parseFloatOption),
+      )
+      .addOption(
+        new Option(
+          '--retry-success-threshold <count>',
+          'Number of successful operations before resetting retry count',
+        )
+          .env('RETRY_SUCCESS_THRESHOLD')
+          .default('5')
+          .argParser(parseIntOption),
+      )
+      .addOption(
+        new Option(
+          '--retry-disabled',
+          'Disable retry mechanism completely',
+        ).env('RETRY_DISABLED'),
+      )
+      // Processing options
+      .addOption(
+        new Option(
+          '--resume-from-last-save',
+          'Resume from the last saved state',
+        ).env('RESUME_FROM_LAST_SAVE'),
+      )
+      .addOption(
+        new Option('--output-file <file>', 'Path to file for output data').env(
+          'OUTPUT_FILE',
+        ),
+      )
+      .addOption(
+        new Option(
+          '-f, --output-file-name <file>',
+          'Name of the output file',
+        ).env('OUTPUT_FILE_NAME'),
+      )
+      .addOption(
+        new Option(
+          '--repo-list <file>',
+          'Path to file containing list of repositories to process (format: owner/repo_name)',
+        ).env('REPO_LIST'),
+      )
+      .addOption(
+        new Option(
+          '--auto-process-missing',
+          'Automatically process any missing repositories when main processing is complete',
+        ).env('AUTO_PROCESS_MISSING'),
+      )
+  );
+}
+
+export function createCommandWithSharedOptions(
+  name: string | undefined,
+): Command {
+  const cmd = new Command(name);
+  return withSharedOptions(cmd);
+}

--- a/src/commands/get-package-details.ts
+++ b/src/commands/get-package-details.ts
@@ -3,7 +3,7 @@ import {
   executeWithOctokit,
 } from '@scottluskcis/octokit-harness';
 
-import { Octokit, PageInfoForward } from 'octokit';
+import { Octokit } from 'octokit';
 
 import fs from 'fs';
 import path from 'path';

--- a/src/commands/list-repo-secret-scan-alerts.ts
+++ b/src/commands/list-repo-secret-scan-alerts.ts
@@ -2,7 +2,10 @@ import {
   createCommandWithSharedOptions,
   parseRepoListOption,
 } from '../commands/command-helpers.js';
-import { listAlertsForRepos } from '../api/secret-scanning/secret-scanning-alerts.js';
+import {
+  listAlertsForRepos,
+  listAlertsForOrg,
+} from '../api/secret-scanning/secret-scanning-alerts.js';
 import { executeWithOctokit } from '@scottluskcis/octokit-harness';
 import { Option } from 'commander';
 import * as fs from 'fs';
@@ -17,11 +20,22 @@ import { ensureDirectory, generateTimestampedFilename } from '../utils/file.js';
 const listAlertsForReposCommand = createCommandWithSharedOptions(
   'list-repo-secret-scan-alerts',
 )
-  .description('List secret scanning alerts for specified repositories')
+  .description(
+    'List secret scanning alerts for specified repositories or organization',
+  )
+  .addOption(
+    new Option(
+      '--scan-type <type>',
+      'Type of scan: "repo" for repositories or "org" for organization',
+    )
+      .env('SCAN_TYPE')
+      .choices(['repo', 'org'])
+      .default('repo'),
+  )
   .addOption(
     new Option(
       '--repos <repos...>',
-      'Comma separated list of repositories in the format owner/repo',
+      'Comma separated list of repositories in the format owner/repo (for repo scan type)',
     )
       .env('REPOS')
       .argParser(parseRepoListOption),
@@ -62,18 +76,20 @@ const listAlertsForReposCommand = createCommandWithSharedOptions(
     ).env('IS_MULTI_REPO'),
   )
   .addOption(
-    new Option('--hide-secret', 'Hide the actual secret value in output').env(
-      'HIDE_SECRET',
-    ),
+    new Option('--hide-secret', 'Hide the actual secret value in output')
+      .env('HIDE_SECRET')
+      .default(true),
   )
   .action(async (options) => handleAction(options));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseArgs(options: any) {
+  const scanType = options.scanType || 'repo';
   let repoList = options.repos;
 
   // If no repos option is provided but repoList (file path) exists, read repos from file
-  if (!repoList && options.repoList) {
+  // Only applicable for 'repo' scan type
+  if (scanType === 'repo' && !repoList && options.repoList) {
     const fileContent = fs.readFileSync(options.repoList, 'utf8');
     const lines = fileContent
       .split('\n')
@@ -88,6 +104,8 @@ function parseArgs(options: any) {
   }
 
   const opts = {
+    scanType,
+    org: options.orgName,
     owner: options.orgName,
     repo: undefined,
     repos: repoList,
@@ -108,37 +126,63 @@ function parseArgs(options: any) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function handleAction(options: any) {
   await executeWithOctokit(options, async ({ octokit, logger }) => {
-    logger.info('Starting to list secret scanning alerts...');
-
     const opts = {
       octokit,
       ...parseArgs(options),
     };
 
+    const scanType = opts.scanType;
+
+    // Validate inputs based on scan type
+    if (scanType === 'repo' && (!opts.repos || opts.repos.length === 0)) {
+      logger.error(
+        'Error: --repos option or --repo-list file is required for repo scan type',
+      );
+      process.exit(1);
+    }
+
+    if (scanType === 'org' && !opts.org) {
+      logger.error('Error: --org-name option is required for org scan type');
+      process.exit(1);
+    }
+
+    logger.info(
+      `Starting to list secret scanning alerts (${scanType} mode)...`,
+    );
+
     // Set up output directory and file path
     const outputDir = path.join(process.cwd(), 'output');
     ensureDirectory(outputDir);
 
-    // Use provided output filename or generate a default timestamped one
+    // Use provided output filename or generate a default timestamped one with scan type
     const filename =
       opts.outputFileName ||
-      generateTimestampedFilename('secret-scanning-alerts', 'csv');
+      generateTimestampedFilename(`secret-scanning-alerts-${scanType}`, 'csv');
     const csvFilePath = path.join(outputDir, filename);
 
     let headers: string[] = [];
     let isFirstAlert = true;
 
-    for await (const alert of listAlertsForRepos({ ...opts })) {
+    // Choose the appropriate function based on scan type
+    const alertIterator =
+      scanType === 'org'
+        ? listAlertsForOrg({ ...opts })
+        : listAlertsForRepos({ ...opts });
+
+    for await (const alert of alertIterator) {
       // On first alert, extract headers and initialize CSV file
       if (isFirstAlert) {
-        headers = extractHeaders(alert);
+        // Add scanType to the alert object for CSV output
+        const alertWithType = { scanType, ...alert };
+        headers = extractHeaders(alertWithType);
         initializeCsvFile(csvFilePath, headers);
         isFirstAlert = false;
         logger.info(`Initialized CSV file: ${csvFilePath}`);
       }
 
-      // Append alert to CSV file
-      appendRecordToCsv(csvFilePath, alert, headers);
+      // Append alert to CSV file with scanType included
+      const alertWithType = { scanType, ...alert };
+      appendRecordToCsv(csvFilePath, alertWithType, headers);
     }
 
     if (isFirstAlert) {

--- a/src/commands/list-repo-secret-scan-alerts.ts
+++ b/src/commands/list-repo-secret-scan-alerts.ts
@@ -1,0 +1,152 @@
+import {
+  createCommandWithSharedOptions,
+  parseRepoListOption,
+} from '../commands/command-helpers.js';
+import { listAlertsForRepos } from '../api/secret-scanning/secret-scanning-alerts.js';
+import { executeWithOctokit } from '@scottluskcis/octokit-harness';
+import { Option } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  initializeCsvFile,
+  appendRecordToCsv,
+  extractHeaders,
+} from '../utils/csv.js';
+import { ensureDirectory, generateTimestampedFilename } from '../utils/file.js';
+
+const listAlertsForReposCommand = createCommandWithSharedOptions(
+  'list-repo-secret-scan-alerts',
+)
+  .description('List secret scanning alerts for specified repositories')
+  .addOption(
+    new Option(
+      '--repos <repos...>',
+      'Comma separated list of repositories in the format owner/repo',
+    )
+      .env('REPOS')
+      .argParser(parseRepoListOption),
+  )
+  .addOption(
+    new Option(
+      '--state <state>',
+      'State of the secret scanning alerts (open, resolved)',
+    ).env('STATE'),
+  )
+  .addOption(
+    new Option('--secret-type <type>', 'Type of secret to filter by').env(
+      'SECRET_TYPE',
+    ),
+  )
+  .addOption(
+    new Option(
+      '--resolution <resolution>',
+      'Resolution status of the alert',
+    ).env('RESOLUTION'),
+  )
+  .addOption(
+    new Option(
+      '--validity <validity>',
+      'Validity of the secret (active, inactive, unknown)',
+    ).env('VALIDITY'),
+  )
+  .addOption(
+    new Option(
+      '--is-publicly-leaked',
+      'Filter for publicly leaked secrets',
+    ).env('IS_PUBLICLY_LEAKED'),
+  )
+  .addOption(
+    new Option(
+      '--is-multi-repo',
+      'Filter for secrets found in multiple repositories',
+    ).env('IS_MULTI_REPO'),
+  )
+  .addOption(
+    new Option('--hide-secret', 'Hide the actual secret value in output').env(
+      'HIDE_SECRET',
+    ),
+  )
+  .action(async (options) => handleAction(options));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseArgs(options: any) {
+  let repoList = options.repos;
+
+  // If no repos option is provided but repoList (file path) exists, read repos from file
+  if (!repoList && options.repoList) {
+    const fileContent = fs.readFileSync(options.repoList, 'utf8');
+    const lines = fileContent
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    // Parse each line as owner/repo format
+    repoList = lines.map((line) => {
+      const [owner, repo] = line.split('/');
+      return { owner, repo };
+    });
+  }
+
+  const opts = {
+    owner: options.orgName,
+    repo: undefined,
+    repos: repoList,
+    state: options.state,
+    secret_type: options.secretType,
+    resolution: options.resolution,
+    validity: options.validity,
+    page: options.page,
+    per_page: options.pageSize,
+    is_publicly_leaked: options.isPubliclyLeaked,
+    is_multi_repo: options.isMultiRepo,
+    hide_secret: options.hideSecret,
+    outputFileName: options.outputFileName,
+  };
+  return opts;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function handleAction(options: any) {
+  await executeWithOctokit(options, async ({ octokit, logger }) => {
+    logger.info('Starting to list secret scanning alerts...');
+
+    const opts = {
+      octokit,
+      ...parseArgs(options),
+    };
+
+    // Set up output directory and file path
+    const outputDir = path.join(process.cwd(), 'output');
+    ensureDirectory(outputDir);
+
+    // Use provided output filename or generate a default timestamped one
+    const filename =
+      opts.outputFileName ||
+      generateTimestampedFilename('secret-scanning-alerts', 'csv');
+    const csvFilePath = path.join(outputDir, filename);
+
+    let headers: string[] = [];
+    let isFirstAlert = true;
+
+    for await (const alert of listAlertsForRepos({ ...opts })) {
+      // On first alert, extract headers and initialize CSV file
+      if (isFirstAlert) {
+        headers = extractHeaders(alert);
+        initializeCsvFile(csvFilePath, headers);
+        isFirstAlert = false;
+        logger.info(`Initialized CSV file: ${csvFilePath}`);
+      }
+
+      // Append alert to CSV file
+      appendRecordToCsv(csvFilePath, alert, headers);
+    }
+
+    if (isFirstAlert) {
+      logger.info('No alerts found.');
+    } else {
+      logger.info(`Secret scanning alerts written to: ${csvFilePath}`);
+    }
+  });
+}
+
+export default listAlertsForReposCommand;

--- a/src/commands/list-repo-secret-scan-alerts.ts
+++ b/src/commands/list-repo-secret-scan-alerts.ts
@@ -155,9 +155,9 @@ async function handleAction(options: any) {
     ensureDirectory(outputDir);
 
     // Use provided output filename or generate a default timestamped one with scan type
+    const baseFilename = `secret-scanning-alerts-${scanType}${opts.is_publicly_leaked ? '-publicly-leaked' : ''}`;
     const filename =
-      opts.outputFileName ||
-      generateTimestampedFilename(`secret-scanning-alerts-${scanType}`, 'csv');
+      opts.outputFileName || generateTimestampedFilename(baseFilename, 'csv');
     const csvFilePath = path.join(outputDir, filename);
 
     let headers: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import listWebhooksCommand from './commands/list-webhooks.js';
 import listTeamMembersCommand from './commands/list-team-members.js';
 import codespacesUsageCommand from './commands/codespaces-usage.js';
 import getMigrationExportStatusCommand from './commands/migration-export-status.js';
+import listRepoSecretScanAlertsCommand from './commands/list-repo-secret-scan-alerts.js';
 
 const program = createProgram({
   name: 'octokit-sandbox',
@@ -23,6 +24,7 @@ const program = createProgram({
     listTeamMembersCommand,
     codespacesUsageCommand,
     getMigrationExportStatusCommand,
+    listRepoSecretScanAlertsCommand,
   ],
 });
 

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+
+/**
+ * Flattens a nested object into a single level object with dot notation keys
+ * @param obj - The object to flatten
+ * @param prefix - Prefix for the keys (used during recursion)
+ * @returns Flattened object
+ */
+export function flattenObject(
+  obj: Record<string, unknown>,
+  prefix = '',
+): Record<string, string | number | boolean | null> {
+  const flattened: Record<string, string | number | boolean | null> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const value = obj[key];
+      const newKey = prefix ? `${prefix}_${key}` : key;
+
+      if (value === null || value === undefined) {
+        flattened[newKey] = null;
+      } else if (typeof value === 'object' && !Array.isArray(value)) {
+        // Recursively flatten nested objects
+        Object.assign(
+          flattened,
+          flattenObject(value as Record<string, unknown>, newKey),
+        );
+      } else if (Array.isArray(value)) {
+        // Convert arrays to JSON strings
+        flattened[newKey] = JSON.stringify(value);
+      } else {
+        flattened[newKey] = value as string | number | boolean;
+      }
+    }
+  }
+
+  return flattened;
+}
+
+/**
+ * Escapes a CSV field value
+ */
+export function escapeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value);
+
+  // If the value contains comma, quote, or newline, wrap it in quotes and escape quotes
+  if (
+    stringValue.includes(',') ||
+    stringValue.includes('"') ||
+    stringValue.includes('\n')
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+/**
+ * Initializes CSV file with headers
+ */
+export function initializeCsvFile(filePath: string, headers: string[]): void {
+  const headerRow = headers.map(escapeCsvValue).join(',') + '\n';
+  fs.writeFileSync(filePath, headerRow, 'utf8');
+}
+
+/**
+ * Appends a record to the CSV file
+ */
+export function appendRecordToCsv(
+  filePath: string,
+  record: Record<string, unknown>,
+  headers: string[],
+): void {
+  const flattened = flattenObject(record);
+
+  // Create row with values in the same order as headers
+  const row = headers.map((header) => escapeCsvValue(flattened[header]));
+
+  // Append row to file
+  fs.appendFileSync(filePath, row.join(',') + '\n', 'utf8');
+}
+
+/**
+ * Extracts all unique headers from a sample record by flattening it
+ */
+export function extractHeaders(
+  sampleRecord: Record<string, unknown>,
+): string[] {
+  const flattened = flattenObject(sampleRecord);
+  return Object.keys(flattened).sort();
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -181,3 +181,23 @@ export async function downloadExtractAndFindFile(
     throw error;
   }
 }
+
+/**
+ * Ensures a directory exists, creating it if necessary
+ */
+export function ensureDirectory(dirPath: string): void {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+/**
+ * Generates a timestamped filename
+ */
+export function generateTimestampedFilename(
+  prefix: string,
+  extension: string,
+): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${prefix}-${timestamp}.${extension}`;
+}


### PR DESCRIPTION
This pull request introduces a new CLI command to list secret scanning alerts for repositories and organizations, along with supporting utilities and API integrations. It also adds new dependencies and updates the development environment for easier debugging. The main focus is on enabling users to fetch, filter, and export secret scanning alerts to CSV files, with robust options for customization and automation.